### PR TITLE
Update module name to match the repo name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-git/go-git/v5
+module github.com/inclusive-dev-tools/go-git/v5
 
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect


### PR DESCRIPTION
Related to https://github.com/get-woke/woke/issues/181, the `replace` directive in woke's go.mod is causing errors when installing using `go install` https://github.com/get-woke/woke/blob/e2c8222a50cbaa3177311e84bad6216639a6c8bb/go.mod#L49. See https://go.dev/doc/go-get-install-deprecation.

I'd like to remove the `replace` module and use the module directly, but need the module name to match the import name, otherwise I get the following error in `go mod tidy`:

```
	github.com/inclusive-dev-tools/go-git/v5/plumbing/format/gitignore: github.com/inclusive-dev-tools/go-git/v5@v5.4.4: parsing go.mod:
	module declares its path as: github.com/go-git/go-git/v5
	        but was required as: github.com/inclusive-dev-tools/go-git/v5
```

The context around using `replace` is [here](https://github.com/get-woke/woke/pull/117#discussion_r765326788). 

This change will require a new tag, and I'll also need to update woke to use this tag. In the meantime, I've forked this repo to the `get-woke` org and am updating woke to use that fork. Would prefer to go back to this fork once this change has been merged. Thanks!!